### PR TITLE
Unnecessary thread synchronization in RequestLoadSimulator?

### DIFF
--- a/src/main/java/RequestLoadSimulator.java
+++ b/src/main/java/RequestLoadSimulator.java
@@ -11,7 +11,7 @@ public class RequestLoadSimulator {
 	public static final int AVG_QUERIES_PER_REQUEST = 6;
 	public static final int AVG_QUERY_TIME_MILLIS = 60;
 	public static final int NTH_PRIME_TO_FIND = 250; // increase this to make the computation more difficult. 1500 is about 77 millis worth of work.
-	public static final String PATH_TO_TEST_FILE = "1mb.txt";
+	public static final String PATH_TO_TEST_FILE = "5mb.txt";
 
 	public static void main(String[] args) throws InterruptedException {
 		RequestLoadSimulator requestLoadSimulator = new RequestLoadSimulator();
@@ -23,12 +23,7 @@ public class RequestLoadSimulator {
 		List<RequestProcessor> executors = new ArrayList<RequestProcessor>();
 
 		for (int i = 0; i < NUMBER_OF_REQUESTS; i++) {
-			RequestProcessor requestProcessor = new RequestProcessor(i, AVG_QUERIES_PER_REQUEST, AVG_QUERY_TIME_MILLIS, NTH_PRIME_TO_FIND, PATH_TO_TEST_FILE, new Callback() {
-				@Override
-				public void execute() {
-					incrementNumComplete();
-				}
-			});
+			RequestProcessor requestProcessor = new RequestProcessor(i, AVG_QUERIES_PER_REQUEST, AVG_QUERY_TIME_MILLIS, NTH_PRIME_TO_FIND, PATH_TO_TEST_FILE, null);
 			executors.add(requestProcessor);
 		}
 
@@ -45,32 +40,16 @@ public class RequestLoadSimulator {
 		ExecutorService executorService = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
 		executorService.invokeAll(executors);
 
-		synchronized (RequestLoadSimulator.class) {
-			while (numComplete < NUMBER_OF_REQUESTS) {
-				RequestLoadSimulator.class.wait();
-			}
-			long totalMillis = sw.getTime();
-			System.out.println();
-			System.out.println("NUMBER_OF_REQUESTS: "+NUMBER_OF_REQUESTS);
-			System.out.println("THREAD_POOL_SIZE: "+THREAD_POOL_SIZE);
-			System.out.println("AVG_QUERIES_PER_REQUEST: "+AVG_QUERIES_PER_REQUEST);
-			System.out.println("AVG_QUERY_TIME_MILLIS: "+AVG_QUERY_TIME_MILLIS);
-			System.out.println("NTH_PRIME_TO_FIND: "+NTH_PRIME_TO_FIND);
-			System.out.println("PATH_TO_TEST_FILE: "+PATH_TO_TEST_FILE);
-			System.out.println();
-			System.out.println("The program took "+totalMillis+" millis to process "+NUMBER_OF_REQUESTS+" requests which is "+new BigDecimal(((float)NUMBER_OF_REQUESTS/(float)totalMillis*(float)1000)).round(MathContext.DECIMAL32)+" requests per second");
-			System.exit(0);
-		}
+		long totalMillis = sw.getTime();
+		System.out.println();
+		System.out.println("NUMBER_OF_REQUESTS: "+NUMBER_OF_REQUESTS);
+		System.out.println("THREAD_POOL_SIZE: "+THREAD_POOL_SIZE);
+		System.out.println("AVG_QUERIES_PER_REQUEST: "+AVG_QUERIES_PER_REQUEST);
+		System.out.println("AVG_QUERY_TIME_MILLIS: "+AVG_QUERY_TIME_MILLIS);
+		System.out.println("NTH_PRIME_TO_FIND: "+NTH_PRIME_TO_FIND);
+		System.out.println("PATH_TO_TEST_FILE: "+PATH_TO_TEST_FILE);
+		System.out.println();
+		System.out.println("The program took "+totalMillis+" millis to process "+NUMBER_OF_REQUESTS+" requests which is "+new BigDecimal(((float)NUMBER_OF_REQUESTS/(float)totalMillis*(float)1000)).round(MathContext.DECIMAL32)+" requests per second");
+		System.exit(0);
 	}
-
-	private int numComplete = 0;
-
-	private void incrementNumComplete() {
-		synchronized (RequestLoadSimulator.class) {
-			numComplete++;
-		}
-
-		RequestLoadSimulator.class.notifyAll();
-	}
-
 }


### PR DESCRIPTION
This has already been "mentioned" in #2, but I think is worth some more discussion: Maybe I'm missing something, but in `RequestLoadSimulator` you are counting the successfully processed requests and use locking on the class itself for that. The number of successfully processed requests seems to be only used as an abort condition. 

I think this is unnecessary, because "ExecutorService.invokeAll" is already defined to only return in case all threads successfully finished to provide their results.

> Executes the given tasks, returning a list of Futures holding their status and results when all complete. Future.isDone() is true for each element of the returned list.

https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ExecutorService.html#invokeAll(java.util.Collection)

We don't care about those results, though, but can simply remove the callback, locking and abort condition loop entirely. While the loop doesn't influence the runtime too much, the locking for incrementing the counter does have a higher negative impact.

During my executions of the same test with/without locking the results were pretty widespread, but without all the locking they were always larger than with.